### PR TITLE
Alternative GPU type override

### DIFF
--- a/TinyNvidiaUpdateChecker/Forms/GPUSelectorForm.Designer.cs
+++ b/TinyNvidiaUpdateChecker/Forms/GPUSelectorForm.Designer.cs
@@ -32,13 +32,18 @@
             ConfirmBtn = new System.Windows.Forms.Button();
             richTextBox1 = new System.Windows.Forms.RichTextBox();
             comboBox = new System.Windows.Forms.ComboBox();
+            radioButtonDefault = new System.Windows.Forms.RadioButton();
+            radioButtonDesktop = new System.Windows.Forms.RadioButton();
+            radioButtonNotebook = new System.Windows.Forms.RadioButton();
+            groupBoxType = new System.Windows.Forms.GroupBox();
+            groupBoxType.SuspendLayout();
             SuspendLayout();
             // 
             // ConfirmBtn
             // 
             ConfirmBtn.Anchor = System.Windows.Forms.AnchorStyles.Top;
             ConfirmBtn.Enabled = false;
-            ConfirmBtn.Location = new System.Drawing.Point(234, 123);
+            ConfirmBtn.Location = new System.Drawing.Point(252, 249);
             ConfirmBtn.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             ConfirmBtn.Name = "ConfirmBtn";
             ConfirmBtn.Size = new System.Drawing.Size(90, 29);
@@ -55,7 +60,7 @@
             richTextBox1.Name = "richTextBox1";
             richTextBox1.ReadOnly = true;
             richTextBox1.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
-            richTextBox1.Size = new System.Drawing.Size(244, 77);
+            richTextBox1.Size = new System.Drawing.Size(262, 77);
             richTextBox1.TabIndex = 10;
             richTextBox1.TabStop = false;
             richTextBox1.Text = "Multiple GPUs have been identified, which one do you want to search updates for?";
@@ -65,27 +70,76 @@
             comboBox.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             comboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             comboBox.FormattingEnabled = true;
-            comboBox.Location = new System.Drawing.Point(12, 124);
+            comboBox.Location = new System.Drawing.Point(12, 106);
             comboBox.Name = "comboBox";
-            comboBox.Size = new System.Drawing.Size(196, 28);
+            comboBox.Size = new System.Drawing.Size(330, 28);
             comboBox.TabIndex = 0;
             comboBox.SelectedIndexChanged += comboBox_SelectedIndexChanged;
+            // 
+            // radioButtonDefault
+            // 
+            radioButtonDefault.AutoSize = true;
+            radioButtonDefault.Location = new System.Drawing.Point(6, 31);
+            radioButtonDefault.Name = "radioButtonDefault";
+            radioButtonDefault.Size = new System.Drawing.Size(94, 24);
+            radioButtonDefault.TabIndex = 12;
+            radioButtonDefault.TabStop = true;
+            radioButtonDefault.Text = "Identified";
+            radioButtonDefault.UseVisualStyleBackColor = true;
+            // 
+            // radioButtonDesktop
+            // 
+            radioButtonDesktop.AutoSize = true;
+            radioButtonDesktop.Location = new System.Drawing.Point(116, 31);
+            radioButtonDesktop.Name = "radioButtonDesktop";
+            radioButtonDesktop.Size = new System.Drawing.Size(85, 24);
+            radioButtonDesktop.TabIndex = 13;
+            radioButtonDesktop.TabStop = true;
+            radioButtonDesktop.Text = "Desktop";
+            radioButtonDesktop.UseVisualStyleBackColor = true;
+            // 
+            // radioButtonNotebook
+            // 
+            radioButtonNotebook.AutoSize = true;
+            radioButtonNotebook.Location = new System.Drawing.Point(221, 31);
+            radioButtonNotebook.Name = "radioButtonNotebook";
+            radioButtonNotebook.Size = new System.Drawing.Size(97, 24);
+            radioButtonNotebook.TabIndex = 14;
+            radioButtonNotebook.TabStop = true;
+            radioButtonNotebook.Text = "Notebook";
+            radioButtonNotebook.UseVisualStyleBackColor = true;
+            // 
+            // groupBoxType
+            // 
+            groupBoxType.Controls.Add(radioButtonDefault);
+            groupBoxType.Controls.Add(radioButtonNotebook);
+            groupBoxType.Controls.Add(radioButtonDesktop);
+            groupBoxType.Enabled = false;
+            groupBoxType.Location = new System.Drawing.Point(12, 140);
+            groupBoxType.Name = "groupBoxType";
+            groupBoxType.Size = new System.Drawing.Size(330, 102);
+            groupBoxType.TabIndex = 15;
+            groupBoxType.TabStop = false;
+            groupBoxType.Text = "GPU Type";
             // 
             // GPUSelectorForm
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(336, 171);
+            ClientSize = new System.Drawing.Size(354, 291);
+            Controls.Add(groupBoxType);
             Controls.Add(comboBox);
             Controls.Add(richTextBox1);
             Controls.Add(ConfirmBtn);
             FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
             Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            Icon = System.Drawing.Icon.ExtractAssociatedIcon(System.Windows.Forms.Application.Execut‌​ablePath);
             Name = "GPUSelectorForm";
             StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             Text = "TinyNvidiaUpdateChecker - Choose GPU";
             Load += GPUSelectorForm_Load;
+            groupBoxType.ResumeLayout(false);
+            groupBoxType.PerformLayout();
             ResumeLayout(false);
         }
 
@@ -93,5 +147,9 @@
         private System.Windows.Forms.Button ConfirmBtn;
         private System.Windows.Forms.RichTextBox richTextBox1;
         private System.Windows.Forms.ComboBox comboBox;
+        private System.Windows.Forms.RadioButton radioButtonDefault;
+        private System.Windows.Forms.RadioButton radioButtonDesktop;
+        private System.Windows.Forms.RadioButton radioButtonNotebook;
+        private System.Windows.Forms.GroupBox groupBoxType;
     }
 }

--- a/TinyNvidiaUpdateChecker/Forms/GPUSelectorForm.cs
+++ b/TinyNvidiaUpdateChecker/Forms/GPUSelectorForm.cs
@@ -8,39 +8,56 @@ namespace TinyNvidiaUpdateChecker
     public partial class GPUSelectorForm : Form
     {
         List<GPU> gpuList = null;
-        Dictionary<int, int> validatedList = new();
-        int selectedGpuId;
+        Dictionary<int, GPU> kvGpus = [];
 
         public GPUSelectorForm()
         {
             InitializeComponent();
         }
 
-        public string OpenForm(List<GPU> _gpuList)
+        public (string, string, bool, bool) OpenForm(List<GPU> _gpuList)
         {
             gpuList = _gpuList;
             ShowDialog();
 
-            return selectedGpuId.ToString();
+            GPU gpu = kvGpus[comboBox.SelectedIndex];
+            bool overrideType = !radioButtonDefault.Checked;
+            bool overrideIsDesktop = radioButtonDesktop.Checked;
+
+            if (overrideType) {
+                if (overrideIsDesktop && gpu.type == "desktop") {
+                    overrideType = false;
+                }
+
+                if (radioButtonNotebook.Checked && gpu.type == "notebook") {
+                    overrideType = false;
+                }
+            }
+
+            return (gpu.id.ToString(), gpu.name, overrideType, overrideIsDesktop);
         }
 
         private void GPUSelectorForm_Load(object sender, EventArgs e)
         {
             foreach (var gpu in gpuList.Where(x => x.isValidated)) {
                 int index = comboBox.Items.Add(gpu.name);
-                validatedList.Add(index, gpu.id);
+                kvGpus.Add(index, gpu);
             }
         }
 
         private void ConfirmBtn_Click(object sender, EventArgs e)
         {
-            selectedGpuId = validatedList[comboBox.SelectedIndex];
             Close();
         }
 
         private void comboBox_SelectedIndexChanged(object sender, EventArgs e)
         {
+            groupBoxType.Enabled = true;
             ConfirmBtn.Enabled = true;
+
+            radioButtonDefault.Checked = true;
+            GPU gpu = kvGpus[comboBox.SelectedIndex];
+            radioButtonDefault.Text = $"Identified\n({gpu.getFormattedType()})";
         }
     }
 }

--- a/TinyNvidiaUpdateChecker/Forms/GPUSelectorForm.resx
+++ b/TinyNvidiaUpdateChecker/Forms/GPUSelectorForm.resx
@@ -117,18 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="ConfirmBtn.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="richTextBox1.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="comboBox.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="$this.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/TinyNvidiaUpdateChecker/Handlers/ClassHelper.cs
+++ b/TinyNvidiaUpdateChecker/Handlers/ClassHelper.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 public class OSClass
@@ -9,16 +8,28 @@ public class OSClass
     public int id { get; set; }
 }
 
-public class GPU(string name, string version, string vendorId, string deviceId, bool isValidated, bool isNotebook, bool isDch)
+public class GPU(string name, string version, string vendorId, string deviceId, string type, bool isValidated, bool isDch)
 {
     public string name { get; set; } = name;
     public string version { get; set; } = version;
     public string vendorId { get; set; } = vendorId;
     public string deviceId { get; set; } = deviceId;
-    public int id { get; set; } = 0;
+    public string type { get; set; } = type;
     public bool isValidated { get; set; } = isValidated;
-    public bool isNotebook { get; set; } = isNotebook;
     public bool isDch { get; set; } = isDch;
+    public int id { get; set; } = 0;
+
+    public string getFormattedType()
+    {
+        if (type == "desktop")
+        {
+            return "Desktop";
+        }
+        else
+        {
+            return "Notebook";
+        }
+    }
 }
 
 public class OSClassRoot : List<OSClass> { }

--- a/TinyNvidiaUpdateChecker/Handlers/MetadataHandler.cs
+++ b/TinyNvidiaUpdateChecker/Handlers/MetadataHandler.cs
@@ -44,10 +44,10 @@ namespace TinyNvidiaUpdateChecker.Handlers
             }
         }
 
-        public static (bool, int) GetGpuIdFromName(string name, bool isNotebook)
+        public static (bool, int) GetGpuIdFromName(string name, string type)
         {
             try {
-                int gpuId = (int)cachedGPUData[isNotebook ? "notebook" : "desktop"][name];
+                int gpuId = (int)cachedGPUData[type][name];
                 return (true, gpuId);
             } catch {
                 return (false, 0);


### PR DESCRIPTION
![preview](https://github.com/ElPumpo/TinyNvidiaUpdateChecker/assets/12564301/a8f2927d-ef37-440e-9989-782df8bf1e28)

It shows when choosing GPU type. But it doesn't show if only one GPU is available, and idea scrapped. Refer to #182

Keeping this PR for a reference for possible permanent solutions